### PR TITLE
Typo linea 35

### DIFF
--- a/output/contrib/vacunas_importadas_fabricante_fecha.csv
+++ b/output/contrib/vacunas_importadas_fabricante_fecha.csv
@@ -32,7 +32,7 @@ fecha,origen,laboratorio,cantidad,fuente
 2021-05-27,cargamento,AstraZeneca,204000,https://www.pauta.cl/nacional/cuantas-vacunas-hay-en-chile-covid
 2021-05-27,cargamento,Pfizer,272610,https://cuerpodiplomatico.cl/chile-recibe-mas-de-476mil-dosis-de-vacunas-contra-el-covid-19/
 2021-05-28,discrepancia en el stock,Pfizer,45240,https://www.emol.com/noticias/Nacional/2021/05/31/1022419/disponibilidad-vacunas-tercera-dosis-inmunidad.html
-2021-05-28,cargamento,Cansino,300000,https://www.minciencia.gob.cl/noticias/llegan-chile-las-primeras-300-mil-dosis-de-vacuna-cansino-contra-el-covid-19/
+2021-05-28,cargamento,CanSino,300000,https://www.minciencia.gob.cl/noticias/llegan-chile-las-primeras-300-mil-dosis-de-vacuna-cansino-contra-el-covid-19/
 2021-06-03,cargamento,Pfizer,457470,"https://www.minsal.cl/autoridades-de-salud-reciben-el-mayor-cargamento-de-vacunas-pfizer-contra-el-covid-19/,https://www.elperiodista.cl/2021/06/chile-suspende-vacunacion-con-astrazeneca-en-menores-de-45-anos/"
 2021-06-10,cargamento,Pfizer,451620,"https://www.gob.cl/noticias/covid-19-region-metropolitana-retrocede-cuarentena/, https://ellibero.cl/alerta/todas-las-comunas-de-la-region-metropolitana-retroceden-a-cuarentena/"
 2021-06-16,cargamento,Sinovac,1000000,https://www.subrei.gob.cl/sala-de-prensa/noticias/detalle-noticias/2021/06/16/llega-a-chile-nuevo-cargamento-de-vacunas-sinovac-con-un-mill%C3%B3n-de-dosis


### PR DESCRIPTION
Se corrige un typo en la linea 35, en la cual se indica "cansino" como el nombre de la vacuna "CanSino"

Ahora yo cometi un typo xd

Cierro y creo un nuevo pullrequest